### PR TITLE
Fix documentation navigation and image link

### DIFF
--- a/docs/education/NCES/NCES.md
+++ b/docs/education/NCES/NCES.md
@@ -200,4 +200,4 @@ plt.ylim(0, 100)
 plt.show()
 ```
 
-![](NCES_files/figure-gfm/unnamed-chunk-3-1.png" width="960)
+![](NCES_files/figure-gfm/unnamed-chunk-3-1.png){width="960"}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,6 @@ nav:
       - Nonprofit explorer: education/nonprofit_explorer/nonprofit_explorer.md
       - Global forest change: maka-sitomniya/global_forest_change/global_forest_change.md
       - National Land Cover Database (NLCD): maka-sitomniya/NLCD/NLCD.md
-      - Digital Elevation Map (DEM): maka-sitomniya/LandFire/landfireelevation.md
       - Watershed Boundaries: maka-sitomniya/watershed_boundaries/watershed_boundaries.md
       - NRCS Soil Survey: maka-sitomniya/NRCS/nrcs_soil_exploration.md
       


### PR DESCRIPTION
## Summary
- remove outdated LandFire link from navigation
- correct NCES figure link formatting to render image

## Testing
- `mkdocs build --verbose`

------
https://chatgpt.com/codex/tasks/task_e_689e659cd44083259a26e53b62aba8bc