### PR TITLE
Add automatic tagging system and tag index

### DIFF
--- a/docs/AI/weatherbench/weatherbench.md
+++ b/docs/AI/weatherbench/weatherbench.md
@@ -1,3 +1,9 @@
+---
+tags:
+- ai
+- weatherbench
+---
+
 WeatherBench
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/education/NCES/NCES.md
+++ b/docs/education/NCES/NCES.md
@@ -1,3 +1,9 @@
+---
+tags:
+- education
+- nces
+---
+
 National Center for Education Statistics
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/education/nonprofit_explorer/nonprofit_explorer.md
+++ b/docs/education/nonprofit_explorer/nonprofit_explorer.md
@@ -1,3 +1,9 @@
+---
+tags:
+- education
+- nonprofit_explorer
+---
+
 Nonprofit organizations
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/ethics/wgi/wgi.md
+++ b/docs/ethics/wgi/wgi.md
@@ -1,3 +1,9 @@
+---
+tags:
+- ethics
+- wgi
+---
+
 World Governance Indicators
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/food/FAOSTAT/FAO.md
+++ b/docs/food/FAOSTAT/FAO.md
@@ -1,3 +1,9 @@
+---
+tags:
+- food
+- faostat
+---
+
 Food Balance Sheets
 ================
 

--- a/docs/forecasting/Phenology_network/Phenology_network.md
+++ b/docs/forecasting/Phenology_network/Phenology_network.md
@@ -1,3 +1,9 @@
+---
+tags:
+- forecasting
+- phenology_network
+---
+
 National phenology network
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/forecasting/neon/neon.md
+++ b/docs/forecasting/neon/neon.md
@@ -1,3 +1,9 @@
+---
+tags:
+- forecasting
+- neon
+---
+
 NEON carbon
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/harmonization/dryad/dryad.md
+++ b/docs/harmonization/dryad/dryad.md
@@ -1,3 +1,9 @@
+---
+tags:
+- harmonization
+- dryad
+---
+
 dryad
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/harmonization/neon_and_lter/neon_and_lter.md
+++ b/docs/harmonization/neon_and_lter/neon_and_lter.md
@@ -1,3 +1,9 @@
+---
+tags:
+- harmonization
+- neon_and_lter
+---
+
 NEON and LTER macroinverts powered by ecocomDP
 ================
 

--- a/docs/harmonization/neon_lidar_and_organismal/neon_lidar_and_organismal.md
+++ b/docs/harmonization/neon_lidar_and_organismal/neon_lidar_and_organismal.md
@@ -1,3 +1,9 @@
+---
+tags:
+- harmonization
+- neon_lidar_and_organismal
+---
+
 Fusing NEON LiDAR and Organismal Data
 ================
 Sydne Record & Isaac Shepard of NEON

--- a/docs/hazards/Air_data/Air_data.md
+++ b/docs/hazards/Air_data/Air_data.md
@@ -1,3 +1,9 @@
+---
+tags:
+- hazards
+- air_data
+---
+
 EPA air data
 ================
 Virginia Iglesias, ESIIL Data Scientist

--- a/docs/hazards/FIRED/FIRED.md
+++ b/docs/hazards/FIRED/FIRED.md
@@ -1,3 +1,9 @@
+---
+tags:
+- hazards
+- fired
+---
+
 FIRED
 ================
 Virginia Iglesias, ESIIL Data Scientist

--- a/docs/hazards/ICS209_plus/ICS209_Plus.md
+++ b/docs/hazards/ICS209_plus/ICS209_Plus.md
@@ -1,3 +1,9 @@
+---
+tags:
+- hazards
+- ics209_plus
+---
+
 ICS-209-Plus
 ================
 Virginia Iglesias, ESIIL Data Scientist

--- a/docs/hazards/Uranium_mines/Uranium_mines.md
+++ b/docs/hazards/Uranium_mines/Uranium_mines.md
@@ -1,3 +1,9 @@
+---
+tags:
+- hazards
+- uranium_mines
+---
+
 Uranium Mines and Mills Location Database
 ================
 Virginia Iglesias, ESIIL Data Scientist

--- a/docs/homepage-design-guidelines.md
+++ b/docs/homepage-design-guidelines.md
@@ -1,3 +1,7 @@
+---
+tags: []
+---
+
 # Homepage Design Guidelines
 
 ## Overview

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+tags: []
+---
+
 ESIIL data library and vignette repository
 ================
 

--- a/docs/indian_country/aiannh/AIANNH.md
+++ b/docs/indian_country/aiannh/AIANNH.md
@@ -1,3 +1,9 @@
+---
+tags:
+- indian_country
+- aiannh
+---
+
 American Indian and Alaska Native Areas
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/indian_country/national_atlas_of_indian_lands/National_atlas_of_indian_lands.md
+++ b/docs/indian_country/national_atlas_of_indian_lands/National_atlas_of_indian_lands.md
@@ -1,3 +1,9 @@
+---
+tags:
+- indian_country
+- national_atlas_of_indian_lands
+---
+
 National Atlas - Indian Lands of the United States dataset
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/indian_country/native_lands_digital/native_lands_digital.md
+++ b/docs/indian_country/native_lands_digital/native_lands_digital.md
@@ -1,3 +1,9 @@
+---
+tags:
+- indian_country
+- native_lands_digital
+---
+
 Native lands Digital
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/justice/congress/congress.md
+++ b/docs/justice/congress/congress.md
@@ -1,3 +1,9 @@
+---
+tags:
+- justice
+- congress
+---
+
 U.S. Congress members and their voting records
 ================
 

--- a/docs/justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2000_Census_Tracts/README.md
+++ b/docs/justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2000_Census_Tracts/README.md
@@ -1,3 +1,9 @@
+---
+tags:
+- justice
+- redlining
+---
+
 ﻿#HOLC Polygons and 2000 CensusTracts
 
 Census Tracts were intersected with HOLC Polygons. Census information can be joined via the "nhgis_join" field. The field "perc_tract" gives you the proportion of a given Census Tract in the HOLC Polygon. Assuming equal distribution, you can calculate any variable within a particular graded HOLC neighborhood.

--- a/docs/justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2010_Census_Tracts/README.md
+++ b/docs/justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2010_Census_Tracts/README.md
@@ -1,3 +1,9 @@
+---
+tags:
+- justice
+- redlining
+---
+
 ﻿#HOLC Polygons and 2010 CensusTracts
 
 Census Tracts were intersected with HOLC Polygons. Census information can be joined via the "geoid" field. There are two field "holc_prop" and "tract_prop" which give the proportion of the HOLC polygon in the Census Tract and the proportion of Census Tract in the HOLC Polygon respectively. 

--- a/docs/justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2020_Census_Tracts/README.md
+++ b/docs/justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2020_Census_Tracts/README.md
@@ -1,3 +1,9 @@
+---
+tags:
+- justice
+- redlining
+---
+
 ﻿#HOLC Polygons and 2020 CensusTracts
 
 Census Tracts were intersected with HOLC Polygons. Census information can be joined via the "nhgis_join" field. The field "perc_tract" gives you the proportion of a given Census Tract in the HOLC Polygon. Assuming equal distribution, you can calculate any variable within a particular graded HOLC neighborhood.

--- a/docs/justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/README.md
+++ b/docs/justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/README.md
@@ -1,3 +1,9 @@
+---
+tags:
+- justice
+- redlining
+---
+
 # Census_HOLC_Research
  Census boundary crosswalk with HOLC Polygons
 

--- a/docs/justice/redlining/redlining.md
+++ b/docs/justice/redlining/redlining.md
@@ -1,3 +1,9 @@
+---
+tags:
+- justice
+- redlining
+---
+
 Historic Redlining
 ================
 

--- a/docs/librarian/imls.md
+++ b/docs/librarian/imls.md
@@ -1,3 +1,8 @@
+---
+tags:
+- librarian
+---
+
 Institute of Museum and Library Services (IMLS) Data Catalog
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/maka-sitomniya/NLCD/NLCD.md
+++ b/docs/maka-sitomniya/NLCD/NLCD.md
@@ -1,3 +1,9 @@
+---
+tags:
+- maka-sitomniya
+- nlcd
+---
+
 # National Land Cover Database (NLCD)
 
 ### Overview

--- a/docs/maka-sitomniya/NRCS/nrcs_soil_exploration.md
+++ b/docs/maka-sitomniya/NRCS/nrcs_soil_exploration.md
@@ -1,3 +1,9 @@
+---
+tags:
+- maka-sitomniya
+- nrcs
+---
+
 ## Tutorial: Exploring Soil Data from the NRCS Web Soil Survey (WSS)
 
 This notebook demonstrates how to download, extract, and visualize soil data from the Natural Resources Conservation Service (NRCS) Web Soil Survey (WSS). We will focus on the STATSGO2 dataset for South Dakota.

--- a/docs/maka-sitomniya/global_forest_change/global_forest_change.md
+++ b/docs/maka-sitomniya/global_forest_change/global_forest_change.md
@@ -1,3 +1,9 @@
+---
+tags:
+- maka-sitomniya
+- global_forest_change
+---
+
 # Global Forest Change
 
 ### Overview 

--- a/docs/maka-sitomniya/watershed_boundaries/watershed_boundaries.md
+++ b/docs/maka-sitomniya/watershed_boundaries/watershed_boundaries.md
@@ -1,3 +1,9 @@
+---
+tags:
+- maka-sitomniya
+- watershed_boundaries
+---
+
 # Watershed Boundaries by Hydrologic Unit Code (HUC)
 
 ### Overview

--- a/docs/math/foodweb/foodweb.md
+++ b/docs/math/foodweb/foodweb.md
@@ -1,3 +1,9 @@
+---
+tags:
+- math
+- foodweb
+---
+
 Eco-Florida food network
 ================
 

--- a/docs/math/mammal_primate_association/mammal_primate_associations.md
+++ b/docs/math/mammal_primate_association/mammal_primate_associations.md
@@ -1,3 +1,9 @@
+---
+tags:
+- math
+- mammal_primate_association
+---
+
 Mammal Primate Association
 ================
 

--- a/docs/math/neon_pathogen/neon_pathogen.md
+++ b/docs/math/neon_pathogen/neon_pathogen.md
@@ -1,3 +1,9 @@
+---
+tags:
+- math
+- neon_pathogen
+---
+
 NEON tick pathogen data
 ================
 Sara Paull

--- a/docs/policy/bank_fail/FDIC_Failed_Bank.md
+++ b/docs/policy/bank_fail/FDIC_Failed_Bank.md
@@ -1,3 +1,9 @@
+---
+tags:
+- policy
+- bank_fail
+---
+
 FDIC Failed Banks
 ================
 

--- a/docs/policy/census/US_Census.md
+++ b/docs/policy/census/US_Census.md
@@ -1,3 +1,9 @@
+---
+tags:
+- policy
+- census
+---
+
 US Census
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/remote_sensing/lidar_canopy_height/lidar_canopy_height.md
+++ b/docs/remote_sensing/lidar_canopy_height/lidar_canopy_height.md
@@ -1,3 +1,9 @@
+---
+tags:
+- remote_sensing
+- lidar_canopy_height
+---
+
 Neon Lidar
 ================
 , NEON

--- a/docs/remote_sensing/neon_hyperspectral/neon_hyperspectral.md
+++ b/docs/remote_sensing/neon_hyperspectral/neon_hyperspectral.md
@@ -1,3 +1,9 @@
+---
+tags:
+- remote_sensing
+- neon_hyperspectral
+---
+
 NEON Hyperspectral Data
 ================
 , NEON

--- a/docs/remote_sensing/sentinel2_aws/sentinel2_aws.md
+++ b/docs/remote_sensing/sentinel2_aws/sentinel2_aws.md
@@ -1,3 +1,9 @@
+---
+tags:
+- remote_sensing
+- sentinel2_aws
+---
+
 Sentinel2 Multispectral Data on AWS
 ================
 Erick Verleye, ESIIL Software Developer

--- a/docs/scale/iNaturalist/iNaturalist.md
+++ b/docs/scale/iNaturalist/iNaturalist.md
@@ -1,3 +1,9 @@
+---
+tags:
+- scale
+- inaturalist
+---
+
 Species Occurrence as points
 ================
 

--- a/docs/solutions/osm/osm.md
+++ b/docs/solutions/osm/osm.md
@@ -1,3 +1,9 @@
+---
+tags:
+- solutions
+- osm
+---
+
 Open Street Map vectors
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,242 @@
+# Tags
+
+## ai
+
+- [weatherbench](AI/weatherbench/weatherbench.md)
+
+## aiannh
+
+- [AIANNH](indian_country/aiannh/AIANNH.md)
+
+## air_data
+
+- [Air data](hazards/Air_data/Air_data.md)
+
+## bank_fail
+
+- [FDIC Failed Bank](policy/bank_fail/FDIC_Failed_Bank.md)
+
+## census
+
+- [US Census](policy/census/US_Census.md)
+
+## congress
+
+- [congress](justice/congress/congress.md)
+
+## dryad
+
+- [dryad](harmonization/dryad/dryad.md)
+
+## education
+
+- [NCES](education/NCES/NCES.md)
+- [nonprofit explorer](education/nonprofit_explorer/nonprofit_explorer.md)
+
+## epa_water_quality
+
+- [epa water quality](water/epa_water_quality/epa_water_quality.md)
+
+## ethics
+
+- [wgi](ethics/wgi/wgi.md)
+
+## faostat
+
+- [FAO](food/FAOSTAT/FAO.md)
+
+## fired
+
+- [FIRED](hazards/FIRED/FIRED.md)
+
+## food
+
+- [FAO](food/FAOSTAT/FAO.md)
+
+## foodweb
+
+- [foodweb](math/foodweb/foodweb.md)
+
+## forecasting
+
+- [Phenology network](forecasting/Phenology_network/Phenology_network.md)
+- [neon](forecasting/neon/neon.md)
+
+## global_forest_change
+
+- [global forest change](maka-sitomniya/global_forest_change/global_forest_change.md)
+
+## harmonization
+
+- [dryad](harmonization/dryad/dryad.md)
+- [neon and lter](harmonization/neon_and_lter/neon_and_lter.md)
+- [neon lidar and organismal](harmonization/neon_lidar_and_organismal/neon_lidar_and_organismal.md)
+
+## hazards
+
+- [Air data](hazards/Air_data/Air_data.md)
+- [FIRED](hazards/FIRED/FIRED.md)
+- [ICS209 Plus](hazards/ICS209_plus/ICS209_Plus.md)
+- [Uranium mines](hazards/Uranium_mines/Uranium_mines.md)
+
+## ics209_plus
+
+- [ICS209 Plus](hazards/ICS209_plus/ICS209_Plus.md)
+
+## inaturalist
+
+- [iNaturalist](scale/iNaturalist/iNaturalist.md)
+
+## indian_country
+
+- [AIANNH](indian_country/aiannh/AIANNH.md)
+- [National atlas of indian lands](indian_country/national_atlas_of_indian_lands/National_atlas_of_indian_lands.md)
+- [native lands digital](indian_country/native_lands_digital/native_lands_digital.md)
+
+## justice
+
+- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2000_Census_Tracts/README.md)
+- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2010_Census_Tracts/README.md)
+- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2020_Census_Tracts/README.md)
+- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/README.md)
+- [congress](justice/congress/congress.md)
+- [redlining](justice/redlining/redlining.md)
+
+## librarian
+
+- [imls](librarian/imls.md)
+
+## lidar_canopy_height
+
+- [lidar canopy height](remote_sensing/lidar_canopy_height/lidar_canopy_height.md)
+
+## maka-sitomniya
+
+- [NLCD](maka-sitomniya/NLCD/NLCD.md)
+- [global forest change](maka-sitomniya/global_forest_change/global_forest_change.md)
+- [nrcs soil exploration](maka-sitomniya/NRCS/nrcs_soil_exploration.md)
+- [watershed boundaries](maka-sitomniya/watershed_boundaries/watershed_boundaries.md)
+
+## mammal_primate_association
+
+- [mammal primate associations](math/mammal_primate_association/mammal_primate_associations.md)
+
+## math
+
+- [foodweb](math/foodweb/foodweb.md)
+- [mammal primate associations](math/mammal_primate_association/mammal_primate_associations.md)
+- [neon pathogen](math/neon_pathogen/neon_pathogen.md)
+
+## national_atlas_of_indian_lands
+
+- [National atlas of indian lands](indian_country/national_atlas_of_indian_lands/National_atlas_of_indian_lands.md)
+
+## native_lands_digital
+
+- [native lands digital](indian_country/native_lands_digital/native_lands_digital.md)
+
+## nces
+
+- [NCES](education/NCES/NCES.md)
+
+## neon
+
+- [neon](forecasting/neon/neon.md)
+
+## neon_and_lter
+
+- [neon and lter](harmonization/neon_and_lter/neon_and_lter.md)
+
+## neon_aquatic
+
+- [neon aquatic](water/neon_aquatic/neon_aquatic.md)
+
+## neon_hyperspectral
+
+- [neon hyperspectral](remote_sensing/neon_hyperspectral/neon_hyperspectral.md)
+
+## neon_lidar_and_organismal
+
+- [neon lidar and organismal](harmonization/neon_lidar_and_organismal/neon_lidar_and_organismal.md)
+
+## neon_pathogen
+
+- [neon pathogen](math/neon_pathogen/neon_pathogen.md)
+
+## nlcd
+
+- [NLCD](maka-sitomniya/NLCD/NLCD.md)
+
+## nonprofit_explorer
+
+- [nonprofit explorer](education/nonprofit_explorer/nonprofit_explorer.md)
+
+## nrcs
+
+- [nrcs soil exploration](maka-sitomniya/NRCS/nrcs_soil_exploration.md)
+
+## osm
+
+- [osm](solutions/osm/osm.md)
+
+## phenology_network
+
+- [Phenology network](forecasting/Phenology_network/Phenology_network.md)
+
+## policy
+
+- [FDIC Failed Bank](policy/bank_fail/FDIC_Failed_Bank.md)
+- [US Census](policy/census/US_Census.md)
+
+## redlining
+
+- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2000_Census_Tracts/README.md)
+- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2010_Census_Tracts/README.md)
+- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2020_Census_Tracts/README.md)
+- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/README.md)
+- [redlining](justice/redlining/redlining.md)
+
+## remote_sensing
+
+- [lidar canopy height](remote_sensing/lidar_canopy_height/lidar_canopy_height.md)
+- [neon hyperspectral](remote_sensing/neon_hyperspectral/neon_hyperspectral.md)
+- [sentinel2 aws](remote_sensing/sentinel2_aws/sentinel2_aws.md)
+
+## scale
+
+- [iNaturalist](scale/iNaturalist/iNaturalist.md)
+
+## sentinel2_aws
+
+- [sentinel2 aws](remote_sensing/sentinel2_aws/sentinel2_aws.md)
+
+## solutions
+
+- [osm](solutions/osm/osm.md)
+
+## uranium_mines
+
+- [Uranium mines](hazards/Uranium_mines/Uranium_mines.md)
+
+## usgs_water_services
+
+- [usgs water services](water/usgs_water_services/usgs_water_services.md)
+
+## water
+
+- [epa water quality](water/epa_water_quality/epa_water_quality.md)
+- [neon aquatic](water/neon_aquatic/neon_aquatic.md)
+- [usgs water services](water/usgs_water_services/usgs_water_services.md)
+
+## watershed_boundaries
+
+- [watershed boundaries](maka-sitomniya/watershed_boundaries/watershed_boundaries.md)
+
+## weatherbench
+
+- [weatherbench](AI/weatherbench/weatherbench.md)
+
+## wgi
+
+- [wgi](ethics/wgi/wgi.md)
+

--- a/docs/water/epa_water_quality/epa_water_quality.md
+++ b/docs/water/epa_water_quality/epa_water_quality.md
@@ -1,3 +1,9 @@
+---
+tags:
+- water
+- epa_water_quality
+---
+
 EPA’s Water Quality Data Portal
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/docs/water/neon_aquatic/neon_aquatic.md
+++ b/docs/water/neon_aquatic/neon_aquatic.md
@@ -1,3 +1,9 @@
+---
+tags:
+- water
+- neon_aquatic
+---
+
 Neon aquatic data
 ================
 

--- a/docs/water/usgs_water_services/usgs_water_services.md
+++ b/docs/water/usgs_water_services/usgs_water_services.md
@@ -1,3 +1,9 @@
+---
+tags:
+- water
+- usgs_water_services
+---
+
 USGS Water Services
 ================
 Ty Tuff, ESIIL Data Scientist

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ copyright: 'Copyright &copy; 2023 University of Colorado Boulder'
 # Page tree
 nav:
   - Home: index.md
+  - Tags: tags.md
   - More data:
       - Global native homelands: indian_country/native_lands_digital/native_lands_digital.md
       - USA Federal tribal reservations: indian_country/national_atlas_of_indian_lands/National_atlas_of_indian_lands.md

--- a/scripts/build_tags.py
+++ b/scripts/build_tags.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Generate tag front matter for markdown files and build tag index page."""
+from pathlib import Path
+import re
+import yaml
+
+docs_dir = Path('docs')
+tag_page = docs_dir / 'tags.md'
+
+def derive_tags(md_path):
+    parts = md_path.relative_to(docs_dir).parts[:-1]
+    tags = []
+    for i, p in enumerate(parts):
+        if i < 2:
+            tags.append(p.replace(' ', '-').lower())
+    return tags
+
+def read_title(content, md_path):
+    lines = content.splitlines()
+    if lines and lines[0].startswith('# '):
+        return lines[0][2:].strip()
+    if len(lines) >= 2 and set(lines[1]) == {'='}:
+        return lines[0].strip()
+    return md_path.stem.replace('_', ' ').strip()
+
+tags_map = {}
+for md_path in docs_dir.rglob('*.md'):
+    if md_path == tag_page:
+        continue
+    content = md_path.read_text(encoding='utf-8')
+    frontmatter_match = re.match(r'^---\n(.*?)\n---\n', content, re.DOTALL)
+    if frontmatter_match:
+        fm = yaml.safe_load(frontmatter_match.group(1)) or {}
+        body = content[frontmatter_match.end():]
+    else:
+        fm = {}
+        body = content
+    if not fm.get('tags'):
+        fm['tags'] = derive_tags(md_path)
+        front = '---\n' + yaml.dump(fm, sort_keys=False).strip() + '\n---\n\n'
+        content = front + body.lstrip('\n')
+        md_path.write_text(content, encoding='utf-8')
+    title = read_title(content, md_path)
+    for tag in fm.get('tags', []):
+        tags_map.setdefault(tag, []).append((title, md_path.relative_to(docs_dir).as_posix()))
+
+tag_page.write_text('# Tags\n\n', encoding='utf-8')
+with tag_page.open('a', encoding='utf-8') as f:
+    for tag in sorted(tags_map):
+        f.write(f'## {tag}\n\n')
+        for title, path in sorted(tags_map[tag]):
+            f.write(f'- [{title}]({path})\n')
+        f.write('\n')


### PR DESCRIPTION
## Summary
- automatically derive tags for all markdown dataset pages
- generate a consolidated tag index page for browsing
- expose the new tag index in navigation

## Testing
- `mkdocs build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adcf5cd52c832581824e39e9a95c53