### PR TITLE
Add PRISM interactive map and tiling workflow

### DIFF
--- a/.github/workflows/prism_tiles.yml
+++ b/.github/workflows/prism_tiles.yml
@@ -1,0 +1,59 @@
+name: Build PRISM tiles
+on:
+  workflow_dispatch:
+    inputs:
+      variable:   { description: "ppt|tmax|tmin|tmean|tdmean|vpdmin|vpdmax", required: true,  default: "tmax" }
+      date:       { description: "YYYY-MM-DD (daily) | YYYY-MM (monthly) | YYYY (annual)", required: true, default: "2025-07-15" }
+      freq:       { description: "daily|monthly|annual", required: true, default: "daily" }
+      resolution: { description: "800m|4km|400m", required: true, default: "800m" }
+      dataset:    { description: "an or lt (lt only for monthly 800m)", required: true, default: "an" }
+      tag:        { description: "tile folder name", required: true, default: "tmax_2025-07-15_800m" }
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install GDAL
+        run: sudo apt-get update && sudo apt-get install -y gdal-bin python3-gdal curl unzip
+      - name: Make tiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          VAR="${{ inputs.variable }}"
+          DATE="${{ inputs.date }}"
+          FREQ="${{ inputs.freq }}"
+          RES="${{ inputs.resolution }}"
+          DATASET="${{ inputs.dataset }}"
+          TAG="${{ inputs.tag }}"
+          case "$RES" in
+            800m) RESIN="30s";;
+            4km)  RESIN="25m";;
+            400m) RESIN="15s";;
+            *) echo "bad resolution"; exit 1;;
+          esac
+          # Build datecode
+          DATECODE="$DATE"
+          if [ "$FREQ" = "daily" ]; then DATECODE="${DATE//-/}"; fi
+          if [ "$FREQ" = "monthly" ]; then DATECODE="${DATE:0:7}"; DATECODE="${DATECODE/-/}"; fi
+          if [ "$FREQ" = "annual" ]; then DATECODE="${DATE:0:4}"; fi
+          # LT only for monthly 800m
+          TAIL=""
+          if [ "$DATASET" = "lt" ]; then
+            if [ "$FREQ" != "monthly" ] || [ "$RES" != "800m" ]; then echo "lt only for monthly 800m"; exit 1; fi
+            TAIL="/lt"
+          fi
+          BASE="https://services.nacse.org/prism/data/get/us/$RES/$VAR/$DATECODE$TAIL"
+          INNER="prism_${VAR}_us_${RESIN}_${DATECODE}.tif"
+          mkdir -p /tmp/prism && cd /tmp/prism
+          echo "Fetching $BASE"
+          curl -sS -L -o prism.zip "$BASE"
+          unzip -o prism.zip "$INNER"
+          mkdir -p "$GITHUB_WORKSPACE/docs/assets/prism_tiles/$TAG"
+          gdal2tiles.py -z 0-8 -r near "$INNER" "$GITHUB_WORKSPACE/docs/assets/prism_tiles/$TAG"
+      - name: Commit tiles
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git add docs/assets/prism_tiles
+          git commit -m "Add PRISM tiles ${{ inputs.tag }}" || echo "No changes"
+          git push

--- a/docs/forecasting/prism/prism.md
+++ b/docs/forecasting/prism/prism.md
@@ -7,6 +7,8 @@ tags:
 
 PRISM (U.S. Gridded Climate)
 ================
+[▶ Open Interactive Map](../../prism-map.html){ .md-button .md-button--primary }
+
 Ty Tuff, ESIIL
 2025-09-05
 
@@ -20,6 +22,13 @@ PRISM is a widely used U.S. climate surface: terrain‑aware, quality‑controll
 * **Variables:** `ppt, tmin, tmax, tmean, tdmean, vpdmin, vpdmax` (plus radiation components in normals products).
 * **Streamable:** each file is a **Cloud‑Optimized GeoTIFF** packaged in a **.zip** with predictable names; works cleanly with GDAL’s `/vsizip//vsicurl/`.
 * **Freshness signals:** the web service exposes endpoints for `releaseDate` and `gridCount` so you can decide when to refresh.
+
+## Interactive preview
+
+<iframe src="../../prism-map.html" title="PRISM Interactive Map"
+        style="width:100%;height:70vh;border:1px solid #e5e7eb;border-radius:12px"></iframe>
+
+[🧱 View Pre-tiled Demo](../../prism-tiles-demo.html){ .md-button }
 
 ---
 

--- a/docs/prism-map.html
+++ b/docs/prism-map.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>PRISM Interactive Map (streamed)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+  <style>
+    :root { --shadow: 0 1px 4px rgba(0,0,0,.1); }
+    body {margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;}
+    .toolbar {padding:10px; display:flex; gap:8px; align-items:center; flex-wrap:wrap; box-shadow:var(--shadow);}
+    #map {width:100vw; height: calc(100vh - 62px);}
+    label {font-size:14px; color:#333;}
+    select, input[type="date"], button {padding:4px 6px; font-size:14px;}
+    .msg {margin-left:auto; font-size:13px; color:#666}
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <label>Variable
+      <select id="var">
+        <option value="tmax">tmax (°C×10)</option>
+        <option value="tmin">tmin (°C×10)</option>
+        <option value="tmean">tmean (°C×10)</option>
+        <option value="ppt">ppt (mm)</option>
+        <option value="tdmean">tdmean (°C×10)</option>
+        <option value="vpdmin">vpdmin (hPa)</option>
+        <option value="vpdmax">vpdmax (hPa)</option>
+      </select>
+    </label>
+    <label>Frequency
+      <select id="freq">
+        <option value="daily" selected>daily</option>
+        <option value="monthly">monthly</option>
+        <option value="annual">annual</option>
+      </select>
+    </label>
+    <label>Date
+      <!-- Daily uses YYYY-MM-DD; monthly choose any day in target month -->
+      <input id="date" type="date" value="2025-07-15">
+    </label>
+    <label>Resolution
+      <select id="res">
+        <option value="800m" selected>800 m</option>
+        <option value="4km">4 km</option>
+        <option value="400m">400 m</option>
+      </select>
+    </label>
+    <label>Dataset
+      <select id="dataset" title="LT only valid for monthly 800 m">
+        <option value="an" selected>an (all networks)</option>
+        <option value="lt">lt (monthly 800 m only)</option>
+      </select>
+    </label>
+    <button id="load" title="Fetch zipped COG → unzip → draw">Load</button>
+    <div class="msg" id="msg">Tip: temperatures are °C × 10</div>
+  </div>
+
+  <div id="map"></div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+  <script src="https://unpkg.com/geotiff@2.0.7/dist-browser/geotiff.min.js"></script>
+  <script src="https://unpkg.com/georaster/dist/georaster.browser.min.js"></script>
+  <script src="https://unpkg.com/georaster-layer-for-leaflet/dist/georaster-layer-for-leaflet.min.js"></script>
+
+  <script>
+    // Basemap
+    const map = L.map('map', { preferCanvas: true }).setView([39, -98], 5);
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution:'&copy; OpenStreetMap' }).addTo(map);
+
+    let currentLayer = null;
+    const RES_IN = { "4km":"25m", "800m":"30s", "400m":"15s" }; // filename tag INSIDE ZIP
+    const RES_WS = { "4km":"4km", "800m":"800m", "400m":"400m" }; // web-service param
+
+    function ymd(d){ return d.replaceAll('-',''); }
+    function ym(d){  return d.slice(0,7).replace('-',''); }
+
+    function buildUrlAndInnerName({variable, date, freq, resolution, dataset}) {
+      const region = "us";
+      const datecode = (freq==="daily") ? ymd(date)
+                      : (freq==="monthly") ? ym(date)
+                      : date.slice(0,4);
+      if (dataset==="lt" && !(freq==="monthly" && resolution==="800m")) {
+        throw new Error("dataset='lt' is only valid for monthly 800 m.");
+      }
+      const tail = (dataset==="lt") ? "/lt" : "";
+      const base = `https://services.nacse.org/prism/data/get/${region}/${RES_WS[resolution]}/${variable}/${datecode}${tail}`;
+      const inner = `prism_${variable}_${region}_${RES_IN[resolution]}_${datecode}.tif`;
+      return { zipUrl: base, innerName: inner };
+    }
+
+    function rampRGBA(min, max) {
+      return (v) => {
+        if (v==null || isNaN(v)) return [0,0,0,0];
+        const t = Math.min(1, Math.max(0, (v - min) / (max - min || 1)));
+        const r = Math.round(255 * t);
+        const b = Math.round(255 * (1 - t));
+        return [r, 0, b, 190];
+      };
+    }
+
+    async function loadRaster() {
+      const variable   = document.getElementById('var').value;
+      const freq       = document.getElementById('freq').value;
+      const date       = document.getElementById('date').value;
+      const resolution = document.getElementById('res').value;
+      const dataset    = document.getElementById('dataset').value;
+      const msg        = document.getElementById('msg');
+
+      try {
+        const { zipUrl, innerName } = buildUrlAndInnerName({variable, date, freq, resolution, dataset});
+        msg.textContent = "Fetching grid package…";
+        const resp = await fetch(zipUrl); // may fail if CORS is denied by server
+        if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${zipUrl}`);
+        const buf = await resp.arrayBuffer();
+
+        msg.textContent = "Unzipping…";
+        const zip = await JSZip.loadAsync(buf);
+        const entry = zip.file(innerName);
+        if (!entry) throw new Error(`Inner file not found: ${innerName}`);
+
+        msg.textContent = "Parsing GeoTIFF…";
+        const tiffArrayBuf = await entry.async("arraybuffer");
+        const georaster = await parseGeoraster(tiffArrayBuf);
+
+        const isTemp = ["tmin","tmax","tmean"].includes(variable);
+        const min = (georaster.mins?.[0] ?? 0) / (isTemp ? 10 : 1);
+        const max = (georaster.maxs?.[0] ?? 1) / (isTemp ? 10 : 1);
+        const colorFnRaw = rampRGBA(min, max);
+        const colorFn = (val) => colorFnRaw(isTemp && typeof val==="number" ? val/10.0 : val);
+
+        if (currentLayer) { map.removeLayer(currentLayer); currentLayer = null; }
+        currentLayer = new GeoRasterLayer({
+          georaster,
+          pixelValuesToColorFn: colorFn,
+          resolution: 256,
+          opacity: 0.8
+        }).addTo(map);
+
+        map.fitBounds(currentLayer.getBounds());
+        msg.textContent = `Drawn: ${variable} ${freq} ${date} (${resolution})`;
+      } catch (err) {
+        console.error(err);
+        msg.textContent = "Could not load (likely CORS or bad parameters). See console for details.";
+        if (currentLayer) { map.removeLayer(currentLayer); currentLayer = null; }
+      }
+    }
+
+    document.getElementById('load').addEventListener('click', loadRaster);
+    loadRaster(); // initial draw
+  </script>
+</body>
+</html>

--- a/docs/prism-tiles-demo.html
+++ b/docs/prism-tiles-demo.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html><head>
+<meta charset="utf-8"><title>PRISM Tiles Demo</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+<style>html,body,#map{height:100%;margin:0}</style>
+</head><body>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+  const map = L.map('map').setView([39,-98], 5);
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',{attribution:'&copy; OSM'}).addTo(map);
+  // Replace TAG with your workflow input, e.g., tmax_2025-07-15_800m
+  const TAG = 'tmax_2025-07-15_800m';
+  L.tileLayer('./assets/prism_tiles/'+TAG+'/{z}/{x}/{y}.png', {opacity:0.75, maxZoom:8}).addTo(map);
+</script>
+</body></html>


### PR DESCRIPTION
## Summary
- add client-only Leaflet map that streams zipped PRISM COGs
- link PRISM dataset page to interactive map and optional pre-tiled demo
- add GitHub Action to bake PRISM grids into PNG tiles

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68bb26014b4c8325a4ba717d828f453f