### PR TITLE
Fix PRISM map link and enable CORS proxy

### DIFF
--- a/docs/forecasting/prism/prism.md
+++ b/docs/forecasting/prism/prism.md
@@ -7,7 +7,7 @@ tags:
 
 PRISM (U.S. Gridded Climate)
 ================
-[▶ Open Interactive Map](../../prism-map.html){ .md-button .md-button--primary }
+[▶ Open Interactive Map](../../../prism-map.html){ .md-button .md-button--primary }
 
 Ty Tuff, ESIIL
 2025-09-05
@@ -25,10 +25,10 @@ PRISM is a widely used U.S. climate surface: terrain‑aware, quality‑controll
 
 ## Interactive preview
 
-<iframe src="../../prism-map.html" title="PRISM Interactive Map"
+<iframe src="../../../prism-map.html" title="PRISM Interactive Map"
         style="width:100%;height:70vh;border:1px solid #e5e7eb;border-radius:12px"></iframe>
 
-[🧱 View Pre-tiled Demo](../../prism-tiles-demo.html){ .md-button }
+[🧱 View Pre-tiled Demo](../../../prism-tiles-demo.html){ .md-button }
 
 ---
 

--- a/docs/prism-map.html
+++ b/docs/prism-map.html
@@ -72,6 +72,7 @@
     let currentLayer = null;
     const RES_IN = { "4km":"25m", "800m":"30s", "400m":"15s" }; // filename tag INSIDE ZIP
     const RES_WS = { "4km":"4km", "800m":"800m", "400m":"400m" }; // web-service param
+    const CORS_PROXY = "https://cors.isomorphic-git.org/"; // allow cross-origin requests
 
     function ymd(d){ return d.replaceAll('-',''); }
     function ym(d){  return d.slice(0,7).replace('-',''); }
@@ -85,7 +86,7 @@
         throw new Error("dataset='lt' is only valid for monthly 800 m.");
       }
       const tail = (dataset==="lt") ? "/lt" : "";
-      const base = `https://services.nacse.org/prism/data/get/${region}/${RES_WS[resolution]}/${variable}/${datecode}${tail}`;
+      const base = `${CORS_PROXY}https://services.nacse.org/prism/data/get/${region}/${RES_WS[resolution]}/${variable}/${datecode}${tail}`;
       const inner = `prism_${variable}_${region}_${RES_IN[resolution]}_${datecode}.tif`;
       return { zipUrl: base, innerName: inner };
     }
@@ -111,7 +112,7 @@
       try {
         const { zipUrl, innerName } = buildUrlAndInnerName({variable, date, freq, resolution, dataset});
         msg.textContent = "Fetching grid package…";
-        const resp = await fetch(zipUrl); // may fail if CORS is denied by server
+        const resp = await fetch(zipUrl); // proxied to handle CORS
         if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${zipUrl}`);
         const buf = await resp.arrayBuffer();
 


### PR DESCRIPTION
## Summary
- fix broken PRISM map links in dataset page
- proxy PRISM map requests to bypass CORS

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3ff7af48832586a8defaa012ace4