### PR TITLE
fix: improve PRISM map fetch handling

### DIFF
--- a/docs/prism-map.html
+++ b/docs/prism-map.html
@@ -72,7 +72,8 @@
     let currentLayer = null;
     const RES_IN = { "4km":"25m", "800m":"30s", "400m":"15s" }; // filename tag INSIDE ZIP
     const RES_WS = { "4km":"4km", "800m":"800m", "400m":"400m" }; // web-service param
-    const CORS_PROXY = "https://cors.isomorphic-git.org/"; // allow cross-origin requests
+    // Use direct service calls when possible; set to proxy URL (ending with `/`) only if needed
+    const CORS_PROXY = ""; // e.g., "https://cors.isomorphic-git.org/"
 
     function ymd(d){ return d.replaceAll('-',''); }
     function ym(d){  return d.slice(0,7).replace('-',''); }
@@ -86,7 +87,7 @@
         throw new Error("dataset='lt' is only valid for monthly 800 m.");
       }
       const tail = (dataset==="lt") ? "/lt" : "";
-      const base = `${CORS_PROXY}https://services.nacse.org/prism/data/get/${region}/${RES_WS[resolution]}/${variable}/${datecode}${tail}`;
+      const base = `https://services.nacse.org/prism/data/get/${region}/${RES_WS[resolution]}/${variable}/${datecode}${tail}`;
       const inner = `prism_${variable}_${region}_${RES_IN[resolution]}_${datecode}.tif`;
       return { zipUrl: base, innerName: inner };
     }
@@ -112,7 +113,16 @@
       try {
         const { zipUrl, innerName } = buildUrlAndInnerName({variable, date, freq, resolution, dataset});
         msg.textContent = "Fetching grid package…";
-        const resp = await fetch(zipUrl); // proxied to handle CORS
+        let resp;
+        try {
+          resp = await fetch(zipUrl);
+        } catch (e) {
+          if (CORS_PROXY) {
+            resp = await fetch(CORS_PROXY + zipUrl);
+          } else {
+            throw e;
+          }
+        }
         if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${zipUrl}`);
         const buf = await resp.arrayBuffer();
 
@@ -143,7 +153,7 @@
         msg.textContent = `Drawn: ${variable} ${freq} ${date} (${resolution})`;
       } catch (err) {
         console.error(err);
-        msg.textContent = "Could not load (likely CORS or bad parameters). See console for details.";
+        msg.textContent = `Could not load: ${err.message}`;
         if (currentLayer) { map.removeLayer(currentLayer); currentLayer = null; }
       }
     }


### PR DESCRIPTION
## Summary
- allow direct PRISM fetch with optional CORS proxy fallback
- surface fetch errors in message for easier debugging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb5d49768c8325852eb4b8ecef1b02