### PR TITLE
Generate tag-based topic navigation

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -118,16 +118,13 @@
 - [nrcs soil exploration](maka-sitomniya/NRCS/nrcs_soil_exploration.md)
 - [osm](solutions/osm/osm.md)
 - [prism](forecasting/prism/prism.md)
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
 - [usgs water services](water/usgs_water_services/usgs_water_services.md)
 - [watershed boundaries](maka-sitomniya/watershed_boundaries/watershed_boundaries.md)
 - [weatherbench](AI/weatherbench/weatherbench.md)
 
 ## justice
 
-- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2000_Census_Tracts/README.md)
-- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2010_Census_Tracts/README.md)
-- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2020_Census_Tracts/README.md)
-- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/README.md)
 - [congress](justice/congress/congress.md)
 - [redlining](justice/redlining/redlining.md)
 
@@ -212,6 +209,10 @@
 
 - [Phenology network](forecasting/Phenology_network/Phenology_network.md)
 
+## png
+
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
+
 ## policy
 
 - [FDIC Failed Bank](policy/bank_fail/FDIC_Failed_Bank.md)
@@ -221,12 +222,20 @@
 
 - [prism](forecasting/prism/prism.md)
 
+## quicklook
+
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
+
+## rangeland
+
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
+
+## rap
+
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
+
 ## redlining
 
-- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2000_Census_Tracts/README.md)
-- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2010_Census_Tracts/README.md)
-- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/2020_Census_Tracts/README.md)
-- [README](justice/redlining/Census_HOLC_Research/Census_HOLC_Research-main/README.md)
 - [redlining](justice/redlining/redlining.md)
 
 ## remote_sensing
@@ -247,6 +256,18 @@
 
 - [osm](solutions/osm/osm.md)
 
+## streamable
+
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
+
+## teaching
+
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
+
+## tiles
+
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
+
 ## uranium_mines
 
 - [Uranium mines](hazards/Uranium_mines/Uranium_mines.md)
@@ -254,6 +275,10 @@
 ## usgs_water_services
 
 - [usgs water services](water/usgs_water_services/usgs_water_services.md)
+
+## vegetation
+
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
 
 ## water
 

--- a/docs/topic/education.md
+++ b/docs/topic/education.md
@@ -1,0 +1,4 @@
+# education
+
+- [NCES](../education/NCES/NCES.md)
+- [nonprofit explorer](../education/nonprofit_explorer/nonprofit_explorer.md)

--- a/docs/topic/forecasting.md
+++ b/docs/topic/forecasting.md
@@ -1,0 +1,5 @@
+# forecasting
+
+- [Phenology network](../forecasting/Phenology_network/Phenology_network.md)
+- [neon](../forecasting/neon/neon.md)
+- [prism](../forecasting/prism/prism.md)

--- a/docs/topic/harmonization.md
+++ b/docs/topic/harmonization.md
@@ -1,0 +1,5 @@
+# harmonization
+
+- [dryad](../harmonization/dryad/dryad.md)
+- [neon and lter](../harmonization/neon_and_lter/neon_and_lter.md)
+- [neon lidar and organismal](../harmonization/neon_lidar_and_organismal/neon_lidar_and_organismal.md)

--- a/docs/topic/hazards.md
+++ b/docs/topic/hazards.md
@@ -1,0 +1,7 @@
+# hazards
+
+- [Air data](../hazards/Air_data/Air_data.md)
+- [FIRED](../hazards/FIRED/FIRED.md)
+- [ICS209 Plus](../hazards/ICS209_plus/ICS209_Plus.md)
+- [Uranium mines](../hazards/Uranium_mines/Uranium_mines.md)
+- [epica dome c ch4](../hazards/epica_dome_c_ch4/epica_dome_c_ch4.md)

--- a/docs/topic/indian_country.md
+++ b/docs/topic/indian_country.md
@@ -1,0 +1,5 @@
+# indian_country
+
+- [AIANNH](../indian_country/aiannh/AIANNH.md)
+- [National atlas of indian lands](../indian_country/national_atlas_of_indian_lands/National_atlas_of_indian_lands.md)
+- [native lands digital](../indian_country/native_lands_digital/native_lands_digital.md)

--- a/docs/topic/justice.md
+++ b/docs/topic/justice.md
@@ -1,0 +1,4 @@
+# justice
+
+- [congress](../justice/congress/congress.md)
+- [redlining](../justice/redlining/redlining.md)

--- a/docs/topic/maka-sitomniya.md
+++ b/docs/topic/maka-sitomniya.md
@@ -1,0 +1,6 @@
+# maka-sitomniya
+
+- [NLCD](../maka-sitomniya/NLCD/NLCD.md)
+- [global forest change](../maka-sitomniya/global_forest_change/global_forest_change.md)
+- [nrcs soil exploration](../maka-sitomniya/NRCS/nrcs_soil_exploration.md)
+- [watershed boundaries](../maka-sitomniya/watershed_boundaries/watershed_boundaries.md)

--- a/docs/topic/math.md
+++ b/docs/topic/math.md
@@ -1,0 +1,5 @@
+# math
+
+- [foodweb](../math/foodweb/foodweb.md)
+- [mammal primate associations](../math/mammal_primate_association/mammal_primate_associations.md)
+- [neon pathogen](../math/neon_pathogen/neon_pathogen.md)

--- a/docs/topic/remote_sensing.md
+++ b/docs/topic/remote_sensing.md
@@ -1,0 +1,5 @@
+# remote_sensing
+
+- [lidar canopy height](../remote_sensing/lidar_canopy_height/lidar_canopy_height.md)
+- [neon hyperspectral](../remote_sensing/neon_hyperspectral/neon_hyperspectral.md)
+- [sentinel2 aws](../remote_sensing/sentinel2_aws/sentinel2_aws.md)

--- a/docs/topic/water.md
+++ b/docs/topic/water.md
@@ -1,0 +1,5 @@
+# water
+
+- [epa water quality](../water/epa_water_quality/epa_water_quality.md)
+- [neon aquatic](../water/neon_aquatic/neon_aquatic.md)
+- [usgs water services](../water/usgs_water_services/usgs_water_services.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,128 +1,80 @@
-site_name: 'ESIIL Data Library'
-site_description: 'Data for May 2023 ESIIL Innovation Summit'
+site_name: ESIIL Data Library
+site_description: Data for May 2023 ESIIL Innovation Summit
 site_author: ESIIL CI team (lead = Ty Tuff)
 site_url: https://cu-esiil.github.io/data-library
-
-# Repository
 repo_name: data-library
 repo_url: https://github.com/cu-esiil/data-library
 edit_uri: edit/main/docs/
-# Copyright
-copyright: 'Copyright &copy; 2023 University of Colorado Boulder'
-
-# Page tree
+copyright: Copyright &copy; 2023 University of Colorado Boulder
 nav:
-  - Home: index.md
-  - Tags: tags.md
-  - Vegetation:
-      - RAP Tiles: vegetation/rap-tiles/rap-tiles.md
-  - More data:
-      - Global native homelands: indian_country/native_lands_digital/native_lands_digital.md
-      - USA Federal tribal reservations: indian_country/national_atlas_of_indian_lands/National_atlas_of_indian_lands.md
-      - All types of tribal land in USA: indian_country/aiannh/AIANNH.md
-      - NEON Aquatic Instrument Data: water/neon_aquatic/neon_aquatic.md
-      - EPA water quality: water/epa_water_quality/epa_water_quality.md
-      - USGS water services: water/usgs_water_services/usgs_water_services.md
-      - Public Libraries Survey: librarian/imls.md 
-      - NEON Hyperspectral Data: remote_sensing/neon_hyperspectral/neon_hyperspectral.md
-      - Lidar-based Canopy Height: remote_sensing/lidar_canopy_height/lidar_canopy_height.md
-      - Multispectral Sentinel-2 on AWS: remote_sensing/sentinel2_aws/sentinel2_aws.md 
-      - Open Street Map: solutions/osm/osm.md
-      - EPA air quality data: hazards/Air_data/Air_data.md
-      - Fire Event Delineation: hazards/FIRED/FIRED.md
-      - US National Incident Management System: hazards/ICS209_plus/ICS209_Plus.md
-      - Uranium mines: hazards/Uranium_mines/Uranium_mines.md
-      - Species Occurrence as points: scale/iNaturalist/iNaturalist.md
-      - World Governance Indicators: ethics/wgi/wgi.md
-      - National Ecological Observation Network: forecasting/neon/neon.md
-      - USA phenology network: forecasting/Phenology_network/Phenology_network.md
-      - Forecasting NEON data: https://github.com/eco4cast/neon4cast-example 
-      - NEON lidar after fire: https://github.com/NEONScience/NEON-Data-Skills/blob/main/tutorials-in-development/ESIIL_InnovationSummit_2023/Python/wildfire/fire_effects_on_veg_structure_using_lidar.ipynb
-      - Data cataloged with publications: harmonization/dryad/dryad.md
-      - NEON and LTER: harmonization/neon_and_lter/neon_and_lter.md
-      - NEON lidar and organismal data: harmonization/neon_lidar_and_organismal/neon_lidar_and_organismal.md
-      - UN Food and Agriculture: food/FAOSTAT/FAO.md
-      - Redlining: justice/redlining/redlining.md
-      - Congressional voting: justice/congress/congress.md
-      - US Census: policy/census/US_Census.md
-      - FDIC Failed Banks list: policy/bank_fail/FDIC_Failed_Bank.md
-      - WeatherBench: AI/weatherbench/weatherbench.md
-      - NEON tick pathogen data: math/neon_pathogen/neon_pathogen.md
-      - Everglades food network: math/foodweb/foodweb.md
-      - Mammal Primate association network: math/mammal_primate_association/mammal_primate_associations.md
-      - Education Statistics: education/NCES/NCES.md
-      - Nonprofit explorer: education/nonprofit_explorer/nonprofit_explorer.md
-      - Global forest change: maka-sitomniya/global_forest_change/global_forest_change.md
-      - National Land Cover Database (NLCD): maka-sitomniya/NLCD/NLCD.md
-      - Watershed Boundaries: maka-sitomniya/watershed_boundaries/watershed_boundaries.md
-      - NRCS Soil Survey: maka-sitomniya/NRCS/nrcs_soil_exploration.md
-      
-# Configuration
+- Home: index.md
+- Topics:
+  - hazards: topic/hazards.md
+  - maka-sitomniya: topic/maka-sitomniya.md
+  - forecasting: topic/forecasting.md
+  - harmonization: topic/harmonization.md
+  - indian_country: topic/indian_country.md
+  - math: topic/math.md
+  - remote_sensing: topic/remote_sensing.md
+  - water: topic/water.md
+  - education: topic/education.md
+  - justice: topic/justice.md
+- Tags: tags.md
 theme:
   highlightjs: true
   name: material
   font:
-    text: 'Open Sans'
-    code: 'Roboto Mono'
-  logo: 'assets/ESIIL_logo.png'
-  favicon: 'assets/favicon.ico'
-  # setting features for the navigation tab
+    text: Open Sans
+    code: Roboto Mono
+  logo: assets/ESIIL_logo.png
+  favicon: assets/favicon.ico
   features:
-    - navigation.sections
-    - navigation.instant
-    - navigation.tracking
-    - navigation.indexes
-    - navigation.top
-    - toc.integrate
-    - toc.follow
-    - content.code.copy
-  # Default values, taken from mkdocs_theme.yml
+  - navigation.sections
+  - navigation.instant
+  - navigation.tracking
+  - navigation.indexes
+  - navigation.top
+  - toc.integrate
+  - toc.follow
+  - content.code.copy
   language: en
   palette:
-    # Palette toggle for light mode
-    - media: "(prefers-color-scheme: white)"
-      primary: 'white'
-      toggle:
-        icon: material/weather-night
-        name: Switch to dark mode
-
-    # Palette toggle for dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      toggle:
-        icon: material/weather-sunny
-        name: Switch to system preference
-
-# Options
+  - media: '(prefers-color-scheme: white)'
+    primary: white
+    toggle:
+      icon: material/weather-night
+      name: Switch to dark mode
+  - media: '(prefers-color-scheme: dark)'
+    scheme: slate
+    toggle:
+      icon: material/weather-sunny
+      name: Switch to system preference
 extra:
   social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/cu-esiil/
+  - icon: fontawesome/brands/github
+    link: https://github.com/cu-esiil/
   analytics:
     provider: google
     property: G-C88FVQM27T
     feedback:
       title: Was this page helpful?
       ratings:
-        - icon: material/thumb-up-outline
-          name: This page was helpful
-          data: 1
-          note: >-
-            Thanks for your feedback!
-        - icon: material/thumb-down-outline
-          name: This page could be improved
-          data: -1
-          note: >- 
-            Thanks for your feedback! Help us improve this page by
-            using our <a href="..." target="_blank" rel="noopener">feedback form</a>.  
+      - icon: material/thumb-up-outline
+        name: This page was helpful
+        data: 1
+        note: Thanks for your feedback!
+      - icon: material/thumb-down-outline
+        name: This page could be improved
+        data: -1
+        note: 'Thanks for your feedback! Help us improve this page by using our <a
+          href="..." target="_blank" rel="noopener">feedback form</a>.  '
 extra_css:
-  - stylesheets/extra.css
-
+- stylesheets/extra.css
 plugins:
-    - search
-    - mkdocstrings
-    - git-revision-date
-    - mkdocs-jupyter:
-          include_source: True
-          ignore_h1_titles: True
-    - no-sitemap
+- search
+- mkdocstrings
+- git-revision-date
+- mkdocs-jupyter:
+    include_source: true
+    ignore_h1_titles: true
+- no-sitemap

--- a/scripts/build_tags.py
+++ b/scripts/build_tags.py
@@ -6,6 +6,8 @@ import yaml
 
 docs_dir = Path('docs')
 tag_page = docs_dir / 'tags.md'
+topic_dir = docs_dir / 'topic'
+mkdocs_path = Path('mkdocs.yml')
 
 def derive_tags(md_path):
     parts = md_path.relative_to(docs_dir).parts[:-1]
@@ -27,6 +29,9 @@ tags_map = {}
 for md_path in docs_dir.rglob('*.md'):
     if md_path == tag_page:
         continue
+    parts = md_path.relative_to(docs_dir).parts
+    if len(parts) > 3 or parts[0] == 'topic':
+        continue
     content = md_path.read_text(encoding='utf-8')
     frontmatter_match = re.match(r'^---\n(.*?)\n---\n', content, re.DOTALL)
     if frontmatter_match:
@@ -35,13 +40,9 @@ for md_path in docs_dir.rglob('*.md'):
     else:
         fm = {}
         body = content
-    if not fm.get('tags'):
-        fm['tags'] = derive_tags(md_path)
-        front = '---\n' + yaml.dump(fm, sort_keys=False).strip() + '\n---\n\n'
-        content = front + body.lstrip('\n')
-        md_path.write_text(content, encoding='utf-8')
+    tags = fm.get('tags') or derive_tags(md_path)
     title = read_title(content, md_path)
-    for tag in fm.get('tags', []):
+    for tag in tags:
         tags_map.setdefault(tag, []).append((title, md_path.relative_to(docs_dir).as_posix()))
 
 tag_page.write_text('# Tags\n\n', encoding='utf-8')
@@ -51,3 +52,27 @@ with tag_page.open('a', encoding='utf-8') as f:
         for title, path in sorted(tags_map[tag]):
             f.write(f'- [{title}]({path})\n')
         f.write('\n')
+
+tag_counts = {tag: len(paths) for tag, paths in tags_map.items()}
+top_tags = [
+    tag
+    for tag, count in sorted(tag_counts.items(), key=lambda x: (-x[1], x[0]))
+    if count > 1 and not any(ch.isdigit() for ch in tag)
+][:10]
+
+topic_dir.mkdir(exist_ok=True)
+for tag in top_tags:
+    tag_file = topic_dir / f'{tag}.md'
+    with tag_file.open('w', encoding='utf-8') as f:
+        f.write(f'# {tag}\n\n')
+        for title, path in sorted(tags_map.get(tag, [])):
+            f.write(f'- [{title}](../{path})\n')
+
+if mkdocs_path.exists():
+    cfg = yaml.safe_load(mkdocs_path.read_text(encoding='utf-8'))
+    cfg['nav'] = [
+        {'Home': 'index.md'},
+        {'Topics': [{tag: f'topic/{tag}.md'} for tag in top_tags]},
+        {'Tags': 'tags.md'},
+    ]
+    mkdocs_path.write_text(yaml.dump(cfg, sort_keys=False), encoding='utf-8')


### PR DESCRIPTION
## Summary
- derive top tags and generate per-tag topic pages
- update MkDocs config to list top topics instead of individual datasets

## Testing
- `python scripts/build_tags.py`
- `python -m py_compile scripts/build_tags.py`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68bf2a0dce7c83259e38a437bb2f4657