### PR TITLE
Add RAP tiles image instructions and caption guidelines

### DIFF
--- a/STYLE_SHEET.md
+++ b/STYLE_SHEET.md
@@ -41,6 +41,9 @@ presentation patterns.
 ## 6. Visual confirmation
 * After a data connection is established, provide a quick visual check:
   * **Maps:** render a static PNG map that can display in the documentation.
+    * Save the image in the same folder as the Markdown file and reference it with a relative path.
+    * Keep images roughly 600–800 px wide so they are clear but lightweight.
+    * Provide descriptive alt text and follow the image with an *italicized caption* explaining what is shown.
   * **Tables:** print the first 10 rows using `head()` or equivalent.
 * Avoid interactive widgets that fail in static build environments.
 
@@ -93,7 +96,9 @@ Plain‑language paragraph...
 ```
 
 ## Visualization
-![](path/to/preview.png)  <!-- or -->
+![](path/to/preview.png){ width=600 }
+*Short caption describing the preview image.*
+<!-- or -->
 ```python
 # show first 10 rows for tabular data
 ```

--- a/docs/vegetation/rap-tiles/rap-tiles.md
+++ b/docs/vegetation/rap-tiles/rap-tiles.md
@@ -114,6 +114,11 @@ plt.axis("off"); plt.title("RAP tiles — PFG 2011 (masked)")
 plt.show()
 ```
 
+<!-- Place the sample mosaic image at rap_tiles_preview.png to display it below. -->
+![RAP tiles mosaic over Boulder, Colorado (perennial forbs and grasses, 2011)](rap_tiles_preview.png){ width=600 }
+
+*RAP tiles mosaic for perennial forbs and grasses (2011), masked, over Boulder, Colorado.*
+
 ## What you get (content & format)
 
 * **Products:** cover (fractional %) and biomass (lbs/acre) series; versioning and scope are documented in RAP 3.0 notes.  


### PR DESCRIPTION
## Summary
- document RAP tiles with guidance for adding a mosaic preview image and caption
- expand style sheet with image size, placement, and caption recommendations

## Testing
- `pytest`
- `mkdocs build` *(warns: missing `rap_tiles_preview.png` image to be supplied separately)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2c9738d48325af0158f17943fcaa