### PR TITLE
Highlight Innovation Summit 2025 in navigation

### DIFF
--- a/docs/innovation-summit-2025.md
+++ b/docs/innovation-summit-2025.md
@@ -1,0 +1,5 @@
+# Innovation Summit 2025
+
+Innovation Summit 2025 is a special event highlighting the latest advances in environmental data science and inclusive innovation. Details about sessions, speakers, and participation will be announced soon.
+
+Stay tuned for updates as we prepare for this exciting gathering.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,7 @@
+/* Custom styles for documentation */
+
+/* Highlight Innovation Summit 2025 nav link */
+a.md-nav__link[href$="innovation-summit-2025/"] {
+    color: #ff4081;
+    font-weight: bold;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ repo_url: https://github.com/cu-esiil/data-library
 edit_uri: edit/main/docs/
 copyright: Copyright &copy; 2023 University of Colorado Boulder
 nav:
+- Innovation Summit 2025: innovation-summit-2025.md
 - Home: index.md
 - Topics:
   - hazards: topic/hazards.md


### PR DESCRIPTION
## Summary
- Add new Innovation Summit 2025 page and link
- Make Innovation Summit 2025 the top sidebar topic
- Highlight link in sidebar with special color styling

## Testing
- `pytest`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68bf301e8c14832595ee9ff5c1dc10b7