### PR TITLE
Add custom Innovation Summit tag page

### DIFF
--- a/docs/innovation-summit-2025.md
+++ b/docs/innovation-summit-2025.md
@@ -1,5 +1,28 @@
 # Innovation Summit 2025
 
-Innovation Summit 2025 is a special event highlighting the latest advances in environmental data science and inclusive innovation. Details about sessions, speakers, and participation will be announced soon.
+[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)
 
-Stay tuned for updates as we prepare for this exciting gathering.
+![Innovation Summit 2025](assets/pre-summit-training-header.png)
+
+- [Air data](hazards/Air_data/Air_data.md)
+- [FAO](food/FAOSTAT/FAO.md)
+- [FIRED](hazards/FIRED/FIRED.md)
+- [NLCD](maka-sitomniya/NLCD/NLCD.md)
+- [Phenology network](forecasting/Phenology_network/Phenology_network.md)
+- [epa water quality](water/epa_water_quality/epa_water_quality.md)
+- [epica dome c ch4](hazards/epica_dome_c_ch4/epica_dome_c_ch4.md)
+- [global forest change](maka-sitomniya/global_forest_change/global_forest_change.md)
+- [iNaturalist](scale/iNaturalist/iNaturalist.md)
+- [lidar canopy height](remote_sensing/lidar_canopy_height/lidar_canopy_height.md)
+- [neon and lter](harmonization/neon_and_lter/neon_and_lter.md)
+- [neon aquatic](water/neon_aquatic/neon_aquatic.md)
+- [neon hyperspectral](remote_sensing/neon_hyperspectral/neon_hyperspectral.md)
+- [neon lidar and organismal](harmonization/neon_lidar_and_organismal/neon_lidar_and_organismal.md)
+- [nrcs soil exploration](maka-sitomniya/NRCS/nrcs_soil_exploration.md)
+- [osm](solutions/osm/osm.md)
+- [prism](forecasting/prism/prism.md)
+- [rap-tiles](vegetation/rap-tiles/rap-tiles.md)
+- [usgs water services](water/usgs_water_services/usgs_water_services.md)
+- [watershed boundaries](maka-sitomniya/watershed_boundaries/watershed_boundaries.md)
+- [weatherbench](AI/weatherbench/weatherbench.md)
+

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -101,6 +101,10 @@
 
 ## innovation-summit-2025
 
+[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)
+
+![Innovation Summit 2025](assets/pre-summit-training-header.png)
+
 - [Air data](hazards/Air_data/Air_data.md)
 - [FAO](food/FAOSTAT/FAO.md)
 - [FIRED](hazards/FIRED/FIRED.md)

--- a/scripts/build_tags.py
+++ b/scripts/build_tags.py
@@ -49,6 +49,9 @@ tag_page.write_text('# Tags\n\n', encoding='utf-8')
 with tag_page.open('a', encoding='utf-8') as f:
     for tag in sorted(tags_map):
         f.write(f'## {tag}\n\n')
+        if tag == 'innovation-summit-2025':
+            f.write('[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)\n\n')
+            f.write('![Innovation Summit 2025](assets/pre-summit-training-header.png)\n\n')
         for title, path in sorted(tags_map[tag]):
             f.write(f'- [{title}]({path})\n')
         f.write('\n')
@@ -68,9 +71,20 @@ for tag in top_tags:
         for title, path in sorted(tags_map.get(tag, [])):
             f.write(f'- [{title}](../{path})\n')
 
+# Custom standalone page for Innovation Summit 2025 tag
+summit_page = docs_dir / 'innovation-summit-2025.md'
+with summit_page.open('w', encoding='utf-8') as f:
+    f.write('# Innovation Summit 2025\n\n')
+    f.write('[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)\n\n')
+    f.write('![Innovation Summit 2025](assets/pre-summit-training-header.png)\n\n')
+    for title, path in sorted(tags_map.get('innovation-summit-2025', [])):
+        f.write(f'- [{title}]({path})\n')
+    f.write('\n')
+
 if mkdocs_path.exists():
     cfg = yaml.safe_load(mkdocs_path.read_text(encoding='utf-8'))
     cfg['nav'] = [
+        {'Innovation Summit 2025': 'innovation-summit-2025.md'},
         {'Home': 'index.md'},
         {'Topics': [{tag: f'topic/{tag}.md'} for tag in top_tags]},
         {'Tags': 'tags.md'},


### PR DESCRIPTION
## Summary
- Generate a dedicated `Innovation Summit 2025` tag page with a link to the ESIIL site and event image
- Embed the same link and image in the tag index
- Update the tag-building script to regenerate the new page and keep the nav pointing at it

## Testing
- `python -m py_compile scripts/build_tags.py`
- `mkdocs build` *(warnings: relative links missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf315f3b2c83259b1f810d856980da