### PR TITLE
Fix Innovation Summit link

### DIFF
--- a/TAG_SYSTEM_HOWTO.md
+++ b/TAG_SYSTEM_HOWTO.md
@@ -123,7 +123,7 @@ def build_tag_pages(docs_dir=Path("docs"), mkdocs_path=Path("mkdocs.yml")):
         for tag in sorted(tags_map):
             f.write(f"## {tag}\n\n")
             if tag == "innovation-summit-2025":
-                f.write("[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)\n\n")
+                f.write("[Visit the Innovation Summit website](https://cu-esiil.github.io/Innovation-Summit-2025/)\n\n")
                 f.write("![Innovation Summit 2025](assets/pre-summit-training-header.png)\n\n")
             for title, path in sorted(tags_map[tag]):
                 desc = summit_descriptions.get(title)
@@ -152,7 +152,7 @@ def build_tag_pages(docs_dir=Path("docs"), mkdocs_path=Path("mkdocs.yml")):
     summit_page = docs_dir / "innovation-summit-2025.md"
     with summit_page.open("w", encoding="utf-8") as f:
         f.write("# Innovation Summit 2025\n\n")
-        f.write("[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)\n\n")
+        f.write("[Visit the Innovation Summit website](https://cu-esiil.github.io/Innovation-Summit-2025/)\n\n")
         f.write("![Innovation Summit 2025](assets/pre-summit-training-header.png)\n\n")
         for title, path in sorted(tags_map.get("innovation-summit-2025", [])):
             desc = summit_descriptions.get(title)

--- a/docs/innovation-summit-2025.md
+++ b/docs/innovation-summit-2025.md
@@ -1,6 +1,6 @@
 # Innovation Summit 2025
 
-[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)
+[Visit the Innovation Summit website](https://cu-esiil.github.io/Innovation-Summit-2025/)
 
 ![Innovation Summit 2025](assets/pre-summit-training-header.png)
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -102,7 +102,7 @@
 
 ## innovation-summit-2025
 
-[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)
+[Visit the Innovation Summit website](https://cu-esiil.github.io/Innovation-Summit-2025/)
 
 ![Innovation Summit 2025](assets/pre-summit-training-header.png)
 

--- a/scripts/build_tags.py
+++ b/scripts/build_tags.py
@@ -100,7 +100,7 @@ with tag_page.open('a', encoding='utf-8') as f:
     for tag in sorted(tags_map):
         f.write(f'## {tag}\n\n')
         if tag == 'innovation-summit-2025':
-            f.write('[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)\n\n')
+            f.write('[Visit the Innovation Summit website](https://cu-esiil.github.io/Innovation-Summit-2025/)\n\n')
             f.write('![Innovation Summit 2025](assets/pre-summit-training-header.png)\n\n')
         for title, path in sorted(tags_map[tag]):
             desc = summit_descriptions.get(title)
@@ -129,7 +129,7 @@ for tag in top_tags:
 summit_page = docs_dir / 'innovation-summit-2025.md'
 with summit_page.open('w', encoding='utf-8') as f:
     f.write('# Innovation Summit 2025\n\n')
-    f.write('[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)\n\n')
+    f.write('[Visit the Innovation Summit website](https://cu-esiil.github.io/Innovation-Summit-2025/)\n\n')
     f.write('![Innovation Summit 2025](assets/pre-summit-training-header.png)\n\n')
     for title, path in sorted(tags_map.get('innovation-summit-2025', [])):
         desc = summit_descriptions.get(title)


### PR DESCRIPTION
## Summary
- Replace outdated Innovation Summit website URL with current `https://cu-esiil.github.io/Innovation-Summit-2025/` across tag docs and generation scripts.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0a217af348325bc2e9f993de43c54