### PR TITLE
Fix How to Contribute link

### DIFF
--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -1,5 +1,0 @@
-# How to Contribute
-
-This placeholder page will contain guidelines for contributing to the ESIIL Data Library.
-
-Stay tuned for more details on how you can help improve this project.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ nav:
   - education: topic/education.md
   - justice: topic/justice.md
 - Tags: tags.md
-- How to Contribute: how-to-contribute.md
+- How to Contribute: https://cu-esiil.github.io/how_to_contribute/
 theme:
   highlightjs: true
   name: material


### PR DESCRIPTION
## Summary
- Point documentation navigation to external How to Contribute page
- Remove obsolete local placeholder file

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68c4882653a48325a0938dd9ec54fc60