### PR TITLE
Update logo link to redirect to OASIS homepage

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ theme:
       icon: material/weather-sunny
       name: Switch to system preference
 extra:
+  homepage: https://cu-esiil.github.io/home/
   social:
   - icon: fontawesome/brands/github
     link: https://github.com/cu-esiil/


### PR DESCRIPTION
## Summary
- configure the Material theme homepage URL so the site logo routes to the main OASIS page

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c8606fe3908325b5cf4cdd3120eea5