### PR TITLE
Update MkDocs logo to oasis version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ theme:
   font:
     text: Open Sans
     code: Roboto Mono
-  logo: assets/ESIIL_logo.png
+  logo: assets/esiil_oasis_logo.png
   favicon: assets/favicon.ico
   features:
   - navigation.sections


### PR DESCRIPTION
## Summary
- update the MkDocs configuration to use the new esiil_oasis logo asset

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c99fa422c083258078442fe35c0839